### PR TITLE
Share snapshot on socials

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
         <label for="imageUpload" class="custom-file-upload">
           Upload Image
         </label>
-        <span class="share-icon"><i class="fa-solid fa-share-nodes"></i></span>
+        <button class="share-icon"><i class="fa-solid fa-share-nodes"></i></button>
         <input type="file" id="imageUpload" accept="image/*" />
       </div>
       <canvas id="snapshotCanvas"></canvas>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <link rel="apple-touch-icon" sizes="144x144" href="Images/logo.png">
   <!-- Add this line -->
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 </head>
 <header class="light-mode">
   <nav >
@@ -70,6 +71,7 @@
         <label for="imageUpload" class="custom-file-upload">
           Upload Image
         </label>
+        <span class="share-icon"><i class="fa-solid fa-share-nodes"></i></span>
         <input type="file" id="imageUpload" accept="image/*" />
       </div>
       <canvas id="snapshotCanvas"></canvas>

--- a/script.js
+++ b/script.js
@@ -326,6 +326,42 @@ function updateSnapshot() {
   }
 }
 
+document.querySelector('.share-icon').addEventListener('click', () => {
+  Swal.fire({
+    title: 'Share Your Daily Insight!',
+    html: `
+        <div class="social-share">
+            <a href="https://www.facebook.com/sharer/sharer.php?u=YOUR_URL" target="_blank" class="social-icon">
+                <i class="fab fa-facebook-f"></i>
+            </a>
+            <a href="https://twitter.com/intent/tweet?url=YOUR_URL" target="_blank" class="social-icon">
+                <i class="fab fa-twitter"></i>
+            </a>
+            <a href="https://www.linkedin.com/sharing/share-offsite/?url=YOUR_URL" target="_blank" class="social-icon">
+                <i class="fab fa-linkedin-in"></i>
+            </a>
+            <a href="https://www.instagram.com/?url=YOUR_URL" target="_blank" class="social-icon">
+                <i class="fab fa-instagram"></i>
+            </a>
+        </div>
+    `,
+    showCloseButton: true,
+    showConfirmButton: false,
+    width: 400,
+    showClass: {
+      popup: 'fadeInUp', 
+  },
+  hideClass: {
+      popup: 'fadeOutDown', 
+  },
+    customClass: {
+      popup: 'share-popup',
+      title: 'share-title',
+    }
+});
+});
+
+
 // Set the initial value of the background select element
 document.addEventListener("DOMContentLoaded", () => {
   const backgroundSelect = document.getElementById("backgroundSelect");

--- a/style.css
+++ b/style.css
@@ -925,3 +925,65 @@ button[type="submit"]:active {
     }
 }
 
+.share-popup {
+  background : linear-gradient(153deg, #111222, #08041f); 
+  border-radius: 10px; /* Rounded corners */
+  border: 2px solid black;
+  padding: 10px;
+}
+
+.share-title {
+  font-size: 30px !important; /* Change this value to adjust the font size */
+  color: var(--text-color-dark) !important; /* Optional: adjust the color */
+  font-weight: bold; /* Optional: make it bold */
+  margin-bottom: 10px; /* Optional: spacing below the title */
+}
+
+
+.social-share {
+  display: flex;
+  justify-content: center;
+}
+
+.social-icon {
+  margin-right: 10px;
+  font-size: 26px;
+  color: var(--button-bg-dark); /* Example color */
+  transition: color 0.3s;
+
+}
+
+.social-icon:hover {
+  color: var(--button-bg-light); /* Color on hover */
+}
+
+@keyframes fadeInUp {
+  0% {
+      opacity: 0;
+      transform: translateY(20px);
+  }
+  100% {
+      opacity: 1;
+      transform: translateY(0);
+  }
+}
+
+@keyframes fadeOutDown {
+  0% {
+      opacity: 1;
+      transform: translateY(0);
+  }
+  100% {
+      opacity: 0;
+      transform: translateY(20px);
+  }
+}
+
+.fadeInUp {
+  animation: fadeInUp 0.5s ease forwards; /* Animation duration and easing */
+}
+
+.fadeOutDown {
+  animation: fadeOutDown 0.5s ease forwards; /* Animation duration and easing */
+}
+

--- a/style.css
+++ b/style.css
@@ -382,6 +382,19 @@ button:active {
 #imageUpload {
     display: none;
 }
+.share-icon{
+  background-color: var(--button-bg-dark);
+  height: 40px;
+  width: 50px;
+  border-radius: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.share-icon:hover{
+  background-color:  var(--button-hover-dark);
+}
 
 #snapshotCanvas {
     width: 100%;
@@ -987,3 +1000,14 @@ button[type="submit"]:active {
   animation: fadeOutDown 0.5s ease forwards; /* Animation duration and easing */
 }
 
+.swal2-close {
+  font-size: 20px; /* Customize size */
+  color: var(--text-color-dark) !important ; /* Customize color */
+  background: var(--button-bg-light) ;
+  border: none;
+  cursor: pointer;
+}
+
+.swal2-close:hover {
+  background: var(--button-bg-light) ;
+}


### PR DESCRIPTION
PR Description
This PR introduces a share button for Creative Zen Snapshots, enabling users to share their visions creatively on social media. The functionality includes a customized SweetAlert with hover effects on social media icons, enhancing user interaction. Additionally, fade-in and fade-out animations have been implemented for the alert, providing a polished user experience.

Related Issues:
Fixes: https://github.com/TheOpenInnovator/Zen-Note/issues/38

Changes:

1. Created a share button that triggers the sharing functionality for Creative Zen Snapshots.
2. Customized the SweetAlert to improve visual appeal and user engagement.
3. Added hover effects to each social media icon for better interactivity.
4. Implemented fade-in and fade-out animations for the SweetAlert to enhance the overall user experience.

Testing Instructions:

1. Pull this branch.
2. Navigate to the Creative Zen Snapshots feature.
3. Click the share button and observe the customized SweetAlert.
4. Hover over the social media icons to verify the hover effects.
5. Test the fade-in and fade-out animations by opening and closing the alert.

Checklist

- [x]  I have performed a self-review of my code.
- [x]  I have commented my code, particularly in hard-to-understand areas.
- [x]  My changes generate no new warnings.
- [x]  I have tested the share functionality, hover effects, and animations.
- [x]  I am working on this issue under Hacktoberfest.



https://github.com/user-attachments/assets/ea0a0293-57b7-4ee2-90cf-c86edaab106b



